### PR TITLE
Replace Google Tasks links with Google Calendar day view

### DIFF
--- a/script.js
+++ b/script.js
@@ -21,7 +21,7 @@ const FACTIONS = [
         enemy: '⚔️',
         label: 'Warrior vs Warrior',
         prayer: '⚔️ O Almighty, grant me the strength to face my mortal enemy.',
-        link: 'https://tasks.google.com',
+        link: 'https://calendar.google.com/calendar/r/day',
         button: 'Accept Mission',
         impact: {
             emoji: '⚔️',
@@ -34,7 +34,7 @@ const FACTIONS = [
         enemy: '🦠',
         label: 'Healer vs Disease',
         prayer: '🧬 O Healer, protect my body and spirit from every disease that approaches.',
-        link: 'https://tasks.google.com',
+        link: 'https://calendar.google.com/calendar/r/day',
         button: 'Begin Self Care',
         impact: {
             emoji: '👨‍⚕️',
@@ -47,7 +47,7 @@ const FACTIONS = [
         enemy: '🍔',
         label: 'Discipline vs Temptation',
         prayer: '💪 O Protector, guard my heart from the pull of temptation.',
-        link: 'https://tasks.google.com',
+        link: 'https://calendar.google.com/calendar/r/day',
         button: 'Stay Strong',
         impact: {
             emoji: '🏃',


### PR DESCRIPTION
### Motivation
- Replace in-game actions that previously opened Google Tasks with the Google Calendar day view to better align CTAs with scheduling behavior.
- Ensure the in-game CTA destination matches the README which references Google Calendar for the `Time to Act` action.
- This is a UX/link-only change and does not alter gameplay logic or formulas.

### Description
- Updated three faction `link` properties in the `FACTIONS` array inside `script.js` to `https://calendar.google.com/calendar/r/day`.
- Left other external links and gameplay code unchanged.
- No README or UI copy changes were required because the README already references Google Calendar.

### Testing
- No automated tests were added because this change does not alter gameplay logic or formulas.
- No automated test suite was executed for this PR.
- Existing tests in the `tests/` directory were not modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69633c5544bc8327bc59500f382495ae)